### PR TITLE
テストの際に使用するメモリ空間をあらかじめゼロクリア

### DIFF
--- a/tests/test.cc
+++ b/tests/test.cc
@@ -2,10 +2,27 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <string.h>
 #include "common/channel.h"
 #include "test.h"
 
+#define DEPLOY_PHYS_ADDR_START 0x80000000UL
+#define DEPLOY_PHYS_ADDR_END 0xC0000000UL
+#define DEPLOY_PHYS_MEM_SIZE (DEPLOY_PHYS_ADDR_END - DEPLOY_PHYS_ADDR_START)
+
 int main(int argc, const char **argv) {
+  // Clear physical memory
+  int physmemfd = open("/dev/mem", O_SYNC);
+  char *mem = static_cast<char *>(mmap(nullptr, DEPLOY_PHYS_MEM_SIZE, PROT_READ|PROT_WRITE, MAP_PRIVATE, physmemfd, DEPLOY_PHYS_ADDR_START));
+  if (mem == MAP_FAILED) {
+    perror("mmap operation failed");
+    return 255;
+  }
+
+  memset(mem, 0, DEPLOY_PHYS_MEM_SIZE);
+
+  close(physmemfd);
+
   int configfd_h2f = open("/sys/module/friend_loader/call/h2f", O_RDWR);
   int configfd_f2h = open("/sys/module/friend_loader/call/f2h", O_RDWR);
   if(configfd_h2f < 0 || configfd_f2h < 0) {


### PR DESCRIPTION
test_main()でこける可能性を考えて，実行後ではなく前に0クリアします